### PR TITLE
Bump nginx version to 1.12.0 (stable)

### DIFF
--- a/opt.d/build-nginx-on-raspbian.sh
+++ b/opt.d/build-nginx-on-raspbian.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
 keyserver=keyserver.ubuntu.com
-ngxversion=1.10.3
+ngxversion=1.12.0
 ngxsigningkey=B0F4253373F8F6F510D42178520A9993A1C052F8
 
 LUAJITURL="http://luajit.org/download/LuaJIT-2.0.3.tar.gz"


### PR DESCRIPTION
1.12.0 became the stable release 2 days ago. Just tested and this seems to build fine on Debian Jessie. Haven't tested Raspbian specifically but I'm pretty sure it uses the same binaries so it should also work there.

https://nginx.org/en/CHANGES-1.12