### PR TITLE
Adding specific domain names to nginx log files

### DIFF
--- a/templates.d/nginx.conf.txt
+++ b/templates.d/nginx.conf.txt
@@ -36,6 +36,12 @@ events {
 }
 
 http {
+
+  # Set custom log status
+  log_format compression '$remote_user [$time_local] %DNS_DOMAIN%'
+                           '"$request" $status $body_bytes_sent '
+                           '"$http_referer" "$http_user_agent" ';
+
   # nginx fails without large enough buckets (sigh)
   map_hash_bucket_size %NGINX_HASH_BUCKET_SIZE%;
   server_names_hash_bucket_size %NGINX_HASH_BUCKET_SIZE%;

--- a/templates.d/nginx.conf.txt
+++ b/templates.d/nginx.conf.txt
@@ -36,12 +36,6 @@ events {
 }
 
 http {
-
-  # Set custom log status
-  log_format compression '$remote_user [$time_local] %DNS_DOMAIN%'
-                           '"$request" $status $body_bytes_sent '
-                           '"$http_referer" "$http_user_agent" ';
-
   # nginx fails without large enough buckets (sigh)
   map_hash_bucket_size %NGINX_HASH_BUCKET_SIZE%;
   server_names_hash_bucket_size %NGINX_HASH_BUCKET_SIZE%;
@@ -698,6 +692,10 @@ http {
   # origin headers not debugged
   %%ENDIF
 
+  # Set custom log status
+  log_format compression '$remote_user [$time_local] %DNS_DOMAIN%'
+                           '"$request" $status $body_bytes_sent '
+                           '"$http_referer" "$http_user_agent" ';
   # header purge
   more_clear_headers "Age";
   more_clear_headers "Server";

--- a/templates.d/nginx.conf.txt
+++ b/templates.d/nginx.conf.txt
@@ -694,7 +694,7 @@ http {
 
   %%BEGIN
   # Set custom log status
-  log_format compression '$remote_user [$time_local] "%DNS_DOMAIN%"'
+  log_format compression '$remote_user [$time_local] %DNS_DOMAIN%'
                            '"$request" $status $body_bytes_sent '
                            '"$http_referer" "$http_user_agent" ';
   %%END

--- a/templates.d/nginx.conf.txt
+++ b/templates.d/nginx.conf.txt
@@ -694,7 +694,7 @@ http {
 
   %%BEGIN
   # Set custom log status
-  log_format compression '$remote_user [$time_local] %DNS_DOMAIN%'
+  log_format compression '$remote_user [$time_local] %DNS_DOMAIN% '
                            '"$request" $status $body_bytes_sent '
                            '"$http_referer" "$http_user_agent" ';
   %%END

--- a/templates.d/nginx.conf.txt
+++ b/templates.d/nginx.conf.txt
@@ -692,10 +692,13 @@ http {
   # origin headers not debugged
   %%ENDIF
 
+  %%BEGIN
   # Set custom log status
-  log_format compression '$remote_user [$time_local] %DNS_DOMAIN%'
+  log_format compression '$remote_user [$time_local] "%DNS_DOMAIN%"'
                            '"$request" $status $body_bytes_sent '
                            '"$http_referer" "$http_user_agent" ';
+  %%END
+  
   # header purge
   more_clear_headers "Age";
   more_clear_headers "Server";


### PR DESCRIPTION
This commit adds the mapped domain to a log file so that you can distinguish between domains in a specific project. (Addressing issue #60)

The generated nginx.config file has a block like:
```
# Set custom log status
  log_format compression '$remote_user [$time_local] example.com '
                           '"$request" $status $body_bytes_sent '
                           '"$http_referer" "$http_user_agent" ';
```