### PR TITLE
Build kludge_disable_sri for testing

### DIFF
--- a/lib.d/do-configure.pl
+++ b/lib.d/do-configure.pl
@@ -593,6 +593,7 @@ my @set_blank = qw(
     host_whitelist_re
     inject_origin
     inject_referer
+    kludge_disable_sri
     log_separate
     nginx_modules_dirs
     no_cache_content_type

--- a/lib.d/lint.pl
+++ b/lib.d/lint.pl
@@ -55,6 +55,7 @@ my %known =
      'INJECT_ORIGIN' => 1,
      'INJECT_REFERER' => 1,
      'IS_SOFTMAP' => 1,
+     'KLUDGE_DISABLE_SRI' => 1,
      'LEFT_TLD_RE' => 1,
      'LOG_DIR' => 1, # where logs for the current project live
      'LOG_SEPARATE' => 1,

--- a/templates.d/nginx.conf.txt
+++ b/templates.d/nginx.conf.txt
@@ -221,6 +221,17 @@ http {
   # no preserve subs (restore-phase)
   %%ENDIF
 
+  %%IF %KLUDGE_DISABLE_SRI%
+  # disabling sri with a kludge
+  subs_filter
+  "i(ntegrity=\"?sha(?:256|384|512)-)"
+  "_$1"
+  gir
+  ;
+  %%ELSE
+  # not disabling sri with a kludge
+  %%ENDIF
+
   # o2d_re_helper -> if cannot remap, return input. NB: old versions
   # of lua-plugin cannot cope with code like o2d_mappings[o[1]]
   # because of `long bracket syntax`; the `[o[` freaks it out.


### PR DESCRIPTION
Subresource integrity (SRI) is a great tool for security, however it inhibits onionification. This is a very kludgy bypass which may impact user-visible content because it does not distinguish between content and HTML/CSS, etc. 

If you are going to be setting up an onion site for your content, and you use SRI, it's better to engineer content to not need rewriting if at all possible, eg: by using relative URLs; or in worst case to have a second set of content for the onion site.