### PR TITLE
Fix Typo and Broken Link

### DIFF
--- a/docs.d/HOW-TO-INSTALL.md
+++ b/docs.d/HOW-TO-INSTALL.md
@@ -97,7 +97,7 @@ that you will need.
 You can then add `set ssl_mkcert 1` to configurations, and your
 `mkcert` root certificate will be used to sign the resulting onion
 certificates. You can [install that certificate into your local copy
-of Tor Browser](docs.d/ADDING-A-ROOT-CERTIFICATE-TO-TOR-BROWSER.md);
+of Tor Browser](/docs.d/ADDING-A-ROOT-CERTIFICATE-TO-TOR-BROWSER.md);
 of course it will not work for anyone else.
 
 ## Visit `/hello-onion/` URLs


### PR DESCRIPTION
Fix broken Link to Add root certificate in tor browser , due to typo error in HOW-TO-INSTALL.md which is the main documentation used by first time visitors.