### PR TITLE
Update tor daemon version

### DIFF
--- a/opt.d/lib.sh
+++ b/opt.d/lib.sh
@@ -60,7 +60,7 @@ ConfigureOpenResty() { # this accepts arguments
 
 SetupTorVars() {
     tool="tor"
-    tool_version="0.4.5.8"
+    tool_version="0.4.5.9"
     tool_signing_keys="6AFEE6D49E92B601 C218525819F78451"
     tool_url="https://dist.torproject.org/$tool-$tool_version.tar.gz"
     tool_sig_url="https://dist.torproject.org/$tool-$tool_version.tar.gz.asc"


### PR DESCRIPTION
0.4.5.8 has several security vulnerabilities which were fixed in 0.4.5.9: https://lists.torproject.org/pipermail/tor-announce/2021-June/000221.html