### PR TITLE
20220305-inject-multiple-extra-headers-upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,33 @@
 
 ## Important HTTPS-related Annoucement: March 2022
 
-I've landed a small breaking change in order to better-support HARICA as a certificate provider, 
+I've landed a small breaking change in order to better-support HARICA as a certificate provider,
 but also for better usability; this change impacts any project with a multi-onion
 EV certificate from Digicert.
 
-* v3 onion addresses used in pathnames are now truncated at 20 chars of onion, rather than 30 overall, to make shorter pathnames for unix domain sockets
+* v3 onion addresses used in pathnames are now truncated at 20 chars
+  of onion, rather than 30 overall, to make shorter pathnames for unix
+  domain sockets
+* onion scratch-directory name changes:
   * was: `projects.d/tweep.d/abcdefghijklmnopqrstuvwxyza-v3.d/port-80.sock`
-  * now: `projects.d/tweep.d/abcdefghijklmnopqrst-v3.d/port-80.sock` 
+  * now: `projects.d/tweep.d/abcdefghijklmnopqrst-v3.d/port-80.sock`
   * this may mean some scratch directories are remade
-* default behaviour changed:
-  * onion HTTPS certificates are now installed in per-onion pathnames
-  * for instance `/projects.d/PROJECTNAME.d/ssl.d/ONIONADDRESS.onion.pem`, for each ONIONADDRESS in PROJECTNAME
-* if you are using 'multi' certificates, where a single certificate contains all SubjectAltNames for all onion addresses in the project
-  * do `set ssl_cert_each_onion 0` in the configuration, to re-enable multi cert handling
-  * now: multi-certificate goes into `projects.d/PROJECTNAME.d/ssl.d/PROJECTNAME.pem`
-  * previously: path would have been `projects.d/PROJECTNAME.d/ssl.d/PRIMARYONIONADDRESSWASHERE.pem`
+* https certificate path-name changes
+  * was: HTTPS certificate files used the full onion address
+  * now: onion HTTPS certificates are now expected to be installed in
+    per-onion-truncated-at-20 pathnames: e.g. for each ONIONADDRESS in
+    PROJECTNAME:
+    * `/projects.d/PROJECTNAME.d/ssl.d/ONIONADDRFIRST20CHAR-v3.onion.cert`
+    * `/projects.d/PROJECTNAME.d/ssl.d/ONIONADDRFIRST20CHAR-v3.onion.pem`
+* if you are using 'multi' certificates (such as Digicert EV) where a
+  single certificate contains all SubjectAltNames for 2+ onion
+  addresses that are part of a single project:
+  * do `set ssl_cert_each_onion 0` in the configuration, to re-enable
+    multi cert handling
+  * was: path would have been
+    `projects.d/PROJECTNAME.d/ssl.d/PRIMARYONIONADDRESSWASHERE.pem`
+  * now: multi-certificate now goes into the more generic/meaningful
+    `projects.d/PROJECTNAME.d/ssl.d/PROJECTNAME.pem`
 
 If you have any issues, please reach out to @alecmuffett on Twitter, or log an issue above.
 

--- a/demo.d/example.tconf
+++ b/demo.d/example.tconf
@@ -34,10 +34,12 @@
 #
 # set x_from_onion_value 1
 
-# Other headers to pass upstream to Origin; be careful not to tread on
-# any which are controlled elsewhere / by other means, such as "Host"
-# or "Accept-Encoding", as those MUST win. See "nginx.conf.txt" for
-# relevant code.
+# Other headers to pass upstream to Origin in order to enable
+# whitelisting, etc; be careful not to tread on any which are
+# controlled elsewhere / by other means, such as "Host" or
+# "Accept-Encoding", as those MUST win.  It is preferred for the
+# Origin to detect and whitelist "X-From-Onion", but this provides an
+# alternative.  See "nginx.conf.txt" for relevant code.
 #
 # set inject_headers_upstream header-name,header-value [...]
 

--- a/demo.d/example.tconf
+++ b/demo.d/example.tconf
@@ -34,6 +34,13 @@
 #
 # set x_from_onion_value 1
 
+# Other headers to pass upstream to Origin; be careful not to tread on
+# any which are controlled elsewhere / by other means, such as "Host"
+# or "Accept-Encoding", as those MUST win. See "nginx.conf.txt" for
+# relevant code.
+#
+# set inject_headers_upstream header-name,header-value [...]
+
 # When you're proving SSL ownership, you may want arbitrary text
 # strings to be returned for a GET upon an arbitrary "/path"
 #

--- a/lib.d/do-configure.pl
+++ b/lib.d/do-configure.pl
@@ -1,7 +1,7 @@
 #!/bin/sh
 exec perl -wx $0 "$@";
 #!perl
-# eotk (c) 2017-2021 Alec Muffett
+# eotk (c) 2017-2022 Alec Muffett
 
 use Data::Dumper;
 
@@ -586,6 +586,7 @@ sub DoProject {
 &SetEnv("suppress_header_hsts", 1); # 1 = elide completely
 &SetEnv("suppress_methods_except_get", 0); # 1 = GET/HEAD Only
 &SetEnv("suppress_tor2web", 1); # 1 = block access by tor2web sites
+
 &SetEnv("template_tool", "$here/lib.d/expand-template.pl");
 &SetEnv("tor_single_onion", 1);
 &SetEnv("tor_syslog", "notice"); # https://www.torproject.org/docs/tor-manual.html.en
@@ -630,6 +631,7 @@ my @set_blank = qw(
     host_blacklist_re
     host_whitelist
     host_whitelist_re
+    inject_headers_upstream
     inject_origin
     inject_referer
     kludge_disable_sri

--- a/lib.d/lint.pl
+++ b/lib.d/lint.pl
@@ -1,7 +1,7 @@
 #!/bin/sh
 exec perl -x $0 "$@";
 #!perl
-# eotk (c) 2017-2021 Alec Muffett
+# eotk (c) 2017-2022 Alec Muffett
 
 my %known =
     (
@@ -52,6 +52,7 @@ my %known =
      'HOST_BLACKLIST_RE' => 1,
      'HOST_WHITELIST' => 1,
      'HOST_WHITELIST_RE' => 1,
+     'INJECT_HEADERS_UPSTREAM' => 1,
      'INJECT_ORIGIN' => 1,
      'INJECT_REFERER' => 1,
      'IS_SOFTMAP' => 1,
@@ -97,6 +98,7 @@ my %known =
      'ONION_ADDRESS_RE6' => 1,
      'ONION_ADDRESS_RE8' => 1,
      'ONION_DIRNAME' => 1,
+     'ONION_TRUNCATED' => 1,
      'ONION_VERSION' => 1,
      'ORIGIN_BLACKLIST' => 1,
      'ORIGIN_BLACKLIST_RE' => 1,

--- a/templates.d/nginx.conf.txt
+++ b/templates.d/nginx.conf.txt
@@ -1,6 +1,6 @@
 # -*- awk -*-
 # EMACS awk mode works quite well for nginx configs
-# eotk (c) 2017-2021 Alec Muffett
+# eotk (c) 2017-2022 Alec Muffett
 
 # TODO LIST:
 
@@ -787,6 +787,15 @@ http {
       # https://blog.g3rt.nl/nginx-add_header-pitfall.html
 
       # request_rewrites and injections:
+      %%IF %INJECT_HEADERS_UPSTREAM%
+      # inject_headers_upstream
+      %%CSV %INJECT_HEADERS_UPSTREAM%
+      proxy_set_header %1% "%2%";
+      %%ENDCSV
+      %%ELSE
+      # no inject_headers_upstream
+      %%ENDIF
+
       proxy_set_header X-From-Onion %X_FROM_ONION_VALUE%;
       proxy_set_header Host "${servernamesubdomain}%DNS_DOMAIN%";
       proxy_set_header Accept-Encoding "identity";

--- a/templates.d/nginx.conf.txt
+++ b/templates.d/nginx.conf.txt
@@ -783,12 +783,13 @@ http {
 
       # a note re: proxy_set_header, add_header, similar methods, etc;
       # if you override *any* header then you will lose the other
-      # headers inherited from the parent contexts:
+      # headers inherited from the parent contexts / other scopes;
+      # ergo: they all need to be "done" in a single bank.
       # https://blog.g3rt.nl/nginx-add_header-pitfall.html
 
-      # request_rewrites and injections:
       %%IF %INJECT_HEADERS_UPSTREAM%
-      # inject_headers_upstream
+      # inject_headers_upstream;
+      # this is above the ones below in order to disambiguate which ones "win"
       %%CSV %INJECT_HEADERS_UPSTREAM%
       proxy_set_header %1% "%2%";
       %%ENDCSV


### PR DESCRIPTION
Be able to pass extra headers upstream to Origin to enable whitelisting, etc; it is easier if the Origin can detect/whitelist the X-From-Onion header, but this is an alternative.