### PR TITLE
Fix: avoid auto-echoing paths on "cd" commands

### DIFF
--- a/eotk
+++ b/eotk
@@ -14,6 +14,9 @@
 cd `dirname $0` || exit 1
 export EOTK_HOME=`pwd`
 
+# avoid the shell auto-echoing paths on "cd" commands by ensuring CDPATH is empty
+export CDPATH=""
+
 # for invoking myself
 prog=`basename $0`
 self=$EOTK_HOME/$prog


### PR DESCRIPTION
Avoid the shell auto-echoing paths on "cd" commands by ensuring CDPATH is empty.

Having a non-empty CDPATH can make the shell output paths to stdout during "cd" commands, which can cause unexpected issues on EOTK like malformed configuration files.

Some users may export CDPATH on their shells as a productivity configuration, so this commit ensures such setting does not affect EOTK.