### PR TITLE
Debian bullseye support

### DIFF
--- a/opt.d/build-debian-bullseye.sh
+++ b/opt.d/build-debian-bullseye.sh
@@ -1,0 +1,38 @@
+#!/bin/sh -x
+
+# platform-independent lib.sh
+cd `dirname $0` || exit 1
+opt_dir=`pwd`
+. ./lib.sh || exit 1
+
+# platform dependencies
+shared_deps="
+build-essential
+curl
+dirmngr
+libevent-dev
+libpcre3-dev
+libssl-dev
+libssl1.1
+make
+perl
+zlib1g-dev
+"
+sudo apt install -y $shared_deps || exit 1
+
+# build openresty
+SetupOpenRestyVars || exit 1
+CustomiseVars || exit 1
+SetupForBuild || exit 1
+ConfigureOpenResty || exit 1
+BuildAndCleanup || exit 1
+
+# build tor
+SetupTorVars || exit 1
+CustomiseVars || exit 1
+SetupForBuild || exit 1
+ConfigureTor || exit 1
+BuildAndCleanup || exit 1
+
+# done
+exit 0


### PR DESCRIPTION
I'm testing EOTK in a Debian bullseye system.

EOTK builds correctly with the exact same procedure for Ubuntu 20.04.

The service is running without issues, but I'm unsure whether specific tests should be performed in order to report this platform as being supported.